### PR TITLE
Add server test script

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Webapp
 
-This simple Node.js webapp serves `index.html` and provides an API endpoint for chart data. The server depends on the following packages:
+This simple Node.js webapp serves `index.html` and provides API endpoints for chart data and LLM-based analysis. The server depends on the following packages:
 
 - `dotenv`
 - `express`
@@ -11,6 +11,11 @@ This simple Node.js webapp serves `index.html` and provides an API endpoint for 
 
 1. Make sure you have Node.js installed.
 2. Run `npm install` to install dependencies.
-3. Create a `.env` file with your `TIINGO_API_KEY` variable.
+3. Create a `.env` file with your `TIINGO_API_KEY` variable. Optionally add `LLM_API_URL` and `LLM_MODEL` to configure the analysis endpoint.
 4. Start the server with `npm start` and open `http://localhost:3000` in your browser.
+5. Run `npm test` to execute the built-in tests.
+
+### Analysis Endpoint
+
+`POST /api/analyze` sends chart data and parameters to a local OpenAI-compatible API (defaults to `http://192.168.1.122:11434/v1/chat/completions` using model `qwen3:8b`) for probabilistic analysis of golden cross events. The request body should include `ticker`, `goldenCrossDate`, `increasePercent`, `sector` and `data`.
 

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "Simple moving average web app",
   "main": "server.js",
   "scripts": {
-    "start": "node server.js"
+    "start": "node server.js",
+    "test": "node --test"
   },
   "keywords": [],
   "author": "",

--- a/server.test.js
+++ b/server.test.js
@@ -1,0 +1,53 @@
+const test = require('node:test');
+const assert = require('node:assert');
+const fetch = global.fetch;
+const axios = require('axios');
+const app = require('./server');
+
+test('POST /api/analyze returns analysis', async () => {
+  const originalPost = axios.post;
+  axios.post = async () => ({ data: { result: 'analysis' } });
+
+  const server = app.listen(0);
+  const port = server.address().port;
+  try {
+    const res = await fetch(`http://localhost:${port}/api/analyze`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        ticker: 'AAPL',
+        goldenCrossDate: '2024-05-01',
+        increasePercent: 10,
+        sector: 'Tech',
+        data: []
+      })
+    });
+    const data = await res.json();
+    assert.strictEqual(res.status, 200);
+    assert.deepStrictEqual(data, { result: 'analysis' });
+  } finally {
+    axios.post = originalPost;
+    server.close();
+  }
+});
+
+test('POST /api/analyze handles errors', async () => {
+  const originalPost = axios.post;
+  axios.post = async () => { throw new Error('fail'); };
+
+  const server = app.listen(0);
+  const port = server.address().port;
+  try {
+    const res = await fetch(`http://localhost:${port}/api/analyze`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({})
+    });
+    const data = await res.json();
+    assert.strictEqual(res.status, 500);
+    assert.ok(data.error);
+  } finally {
+    axios.post = originalPost;
+    server.close();
+  }
+});


### PR DESCRIPTION
## Summary
- export `app` for testing
- add Node-based tests for `/api/analyze`
- run tests with `npm test`
- document test command in README

## Testing
- `npm test` *(fails: Cannot find module 'axios')*


------
https://chatgpt.com/codex/tasks/task_b_683c38c1fdd0832f9a523b417f08a920