### PR TITLE
Fix MA calculation across ranges

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,12 @@ This simple Node.js webapp serves `index.html` and provides API endpoints for ch
 4. Start the server with `npm start` and open `http://localhost:3000` in your browser.
 5. Run `npm test` to execute the built-in tests.
 
+### Chart Data Endpoint
+
+`GET /api/chartdata` now always retrieves five years of historical prices. The
+server calculates moving averages using this full dataset and then filters the
+results to the requested time range (6M, 1Y, 2Y or 5Y).
+
 ### Analysis Endpoint
 
 `POST /api/analyze` sends chart data and parameters to a local OpenAI-compatible API (defaults to `http://192.168.1.122:11434/v1/chat/completions` using model `qwen3:8b`) for probabilistic analysis of golden cross events. The request body should include `ticker`, `goldenCrossDate`, `increasePercent`, `sector` and `data`.

--- a/server.js
+++ b/server.js
@@ -19,32 +19,34 @@ app.get('/', (req, res) => {
 app.get('/api/chartdata', async (req, res) => {
   const ticker = req.query.ticker || 'AAPL';
   const period = req.query.period || '1Y';
-  
-  // Calculate start date based on period
+
+  // Always fetch 5 years of data for consistent MA calculations
   const now = dayjs();
-  let startDate;
-  
-  switch(period) {
+  const fetchStart = now.subtract(5, 'year').format('YYYY-MM-DD');
+
+  // Determine the period range to return to the client
+  let filterStart;
+  switch (period) {
     case '6M':
-      startDate = now.subtract(6, 'month').format('YYYY-MM-DD');
+      filterStart = now.subtract(6, 'month').format('YYYY-MM-DD');
       break;
     case '1Y':
-      startDate = now.subtract(1, 'year').format('YYYY-MM-DD');
+      filterStart = now.subtract(1, 'year').format('YYYY-MM-DD');
       break;
     case '2Y':
-      startDate = now.subtract(2, 'year').format('YYYY-MM-DD');
+      filterStart = now.subtract(2, 'year').format('YYYY-MM-DD');
       break;
     case '5Y':
-      startDate = now.subtract(5, 'year').format('YYYY-MM-DD');
+      filterStart = fetchStart;
       break;
     default:
-      startDate = now.subtract(1, 'year').format('YYYY-MM-DD');
+      filterStart = now.subtract(1, 'year').format('YYYY-MM-DD');
   }
 
   try {
     const response = await axios.get(`https://api.tiingo.com/tiingo/daily/${ticker}/prices`, {
       params: {
-        startDate,
+        startDate: fetchStart,
         resampleFreq: 'daily',
         format: 'json',
         token: process.env.TIINGO_API_KEY
@@ -66,7 +68,10 @@ app.get('/api/chartdata', async (req, res) => {
     const ma50 = calculateMA(data, 50);
     const ma200 = calculateMA(ma50, 200);
 
-    res.json(ma200);
+    // Filter to requested period while keeping MA values from 5y data
+    const filtered = ma200.filter(d => dayjs(d.date).isAfter(filterStart) || d.date === filterStart);
+
+    res.json(filtered);
   } catch (err) {
     console.error(err);
     res.status(500).json({ error: 'Failed to fetch or process data.' });


### PR DESCRIPTION
## Summary
- compute moving averages using a fixed 5 year history and filter data by selected range
- document the new behaviour for `/api/chartdata`

## Testing
- `npm test` *(fails: Cannot find module 'axios')*

------
https://chatgpt.com/codex/tasks/task_b_683c533dcb0c832f8965f6bac905f8ef