### PR TITLE
Fix MA calculation across ranges

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,13 @@ This simple Node.js webapp serves `index.html` and provides API endpoints for ch
 4. Start the server with `npm start` and open `http://localhost:3000` in your browser.
 5. Run `npm test` to execute the built-in tests.
 
+### Chart Data Endpoint
+
+`GET /api/chartdata` always retrieves five years of historical prices. Moving
+averages for 50 and 200 days are calculated from this full history so the lines
+start immediately when viewing shorter ranges. The response is then filtered to
+the requested period (6M, 1Y, 2Y or 5Y).
+
 ### Analysis Endpoint
 
 `POST /api/analyze` sends chart data and parameters to a local OpenAI-compatible API (defaults to `http://192.168.1.122:11434/v1/chat/completions` using model `qwen3:8b`) for probabilistic analysis of golden cross events. The request body should include `ticker`, `goldenCrossDate`, `increasePercent`, `sector` and `data`.


### PR DESCRIPTION
## Summary
- compute moving averages using the full 5‑year history
- merge MA values before filtering results
- update documentation on chart data endpoint

## Testing
- `npm test` *(fails: Cannot find module 'axios')*

------
https://chatgpt.com/codex/tasks/task_b_683c533dcb0c832f8965f6bac905f8ef